### PR TITLE
Add option not to include TOC from input files

### DIFF
--- a/config.py
+++ b/config.py
@@ -56,6 +56,7 @@ default_prefs = {}
 default_prefs['flattentoc'] = False
 default_prefs['includecomments'] = False
 default_prefs['titlenavpoints'] = True
+default_prefs['originalnavpoints'] = True
 default_prefs['keepmeta'] = True
 #default_prefs['showunmerge'] = True
 default_prefs['mergetags'] = ''
@@ -159,6 +160,7 @@ class ConfigWidget(QWidget):
         prefs['flattentoc'] = self.basic_tab.flattentoc.isChecked()
         prefs['includecomments'] = self.basic_tab.includecomments.isChecked()
         prefs['titlenavpoints'] = self.basic_tab.titlenavpoints.isChecked()
+        prefs['originalnavpoints'] = self.basic_tab.originalnavpoints.isChecked()
         prefs['keepmeta'] = self.basic_tab.keepmeta.isChecked()
         # prefs['showunmerge'] = self.basic_tab.showunmerge.isChecked()
         prefs['mergetags'] = unicode(self.basic_tab.mergetags.text())
@@ -204,6 +206,11 @@ class BasicTab(QWidget):
 it's existing TOC nested underneath it.'''))
         self.titlenavpoints.setChecked(prefs['titlenavpoints'])
         self.l.addWidget(self.titlenavpoints)
+
+        self.originalnavpoints = QCheckBox(_('Copy Table of Contents entries from each input epub?'),self)
+        self.originalnavpoints.setToolTip(_('''If set, the original TOC entries will be merged into the new epub.'''))
+        self.originalnavpoints.setChecked(prefs['originalnavpoints'])
+        self.l.addWidget(self.originalnavpoints)
 
         self.flattentoc = QCheckBox(_('Flatten Table of Contents?'),self)
         self.flattentoc.setToolTip(_('Remove nesting and make TOC all on one level.'))

--- a/epubmerge.py
+++ b/epubmerge.py
@@ -52,6 +52,9 @@ Given list of epubs will be merged together into one new epub.
     optparser.add_option("-n", "--no-titles-in-toc",
                       action="store_false", dest="titlenavpoints", default=True,
                       help="Default is to put an entry in the TOC for each epub, nesting each epub's chapters under it.",)
+    optparser.add_option("-N", "--no-original-toc",
+                      action="store_false", dest="originalnavpoints", default=True,
+                      help="Default is to include the TOC from each original epub.",)
     optparser.add_option("-f", "--flatten-toc",
                       action="store_true", dest="flattentoc",
                       help="Flatten TOC down to one level only.",)
@@ -92,6 +95,7 @@ Given list of epubs will be merged together into one new epub.
                 options.tagopts,
                 options.languageopts,
                 options.titlenavpoints,
+                options.originalnavpoints,
                 options.flattentoc,
                 coverjpgpath=options.coveropt,
                 keepmetadatafiles=options.keepmeta,
@@ -118,6 +122,7 @@ def doMerge(outputio,
             tags=[],
             languages=['en'],
             titlenavpoints=True,
+            originalnavpoints=True,
             flattentoc=False,
             printtimes=False,
             coverjpgpath=None,
@@ -132,6 +137,7 @@ def doMerge(outputio,
     tags = dc:subject tags to include, otherwise none.
     languages = dc:language tags to include
     titlenavpoints if true, put in a new TOC entry for each epub, nesting each epub's chapters under it
+    originalnavpoints if true, include the original TOCs from each epub
     flattentoc if true, flatten TOC down to one level only.
     coverjpgpath, Path to a jpg to use as cover image.
     '''
@@ -498,7 +504,7 @@ def doMerge(outputio,
         if not descopt and len(allauthors[booknum]) > 0:
             description.appendChild(contentdom.createTextNode(booktitles[booknum]+" by "+allauthors[booknum][0]+"\n"))
 
-        if len(depthnavpoints) > 1 or not titlenavpoints: # If only one TOC point(total, not top level), or if not
+        if originalnavpoints and (len(depthnavpoints) > 1 or not titlenavpoints): # If only one TOC point(total, not top level), or if not
                                                           # including title nav point, include sub book TOC entries.
             for navpoint in navpoints:
                 newnav.appendChild(navpoint)

--- a/epubmerge_plugin.py
+++ b/epubmerge_plugin.py
@@ -567,6 +567,7 @@ However, the EPUB will *not* be created until after you've reviewed, edited, and
                            tags=mi.tags,
                            languages=mi.languages,
                            titlenavpoints=prefs['titlenavpoints'],
+                           originalnavpoints=prefs['originalnavpoints'],
                            flattentoc=prefs['flattentoc'],
                            printtimes=True,
                            coverjpgpath=coverjpgpath,


### PR DESCRIPTION
If both -N and -n options are specified, then an empty toc will be generated.