### PR TITLE
Fixes and keepsingletocs

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -48,7 +48,7 @@ class EpubMergeBase(InterfaceActionBase):
     description         = _('UI plugin to concatenate multiple epubs into one.')
     supported_platforms = ['windows', 'osx', 'linux']
     author              = 'Jim Miller'
-    version             = (2, 15, 2)
+    version             = (2, 15, 3)
     minimum_calibre_version = (3, 48, 0)
 
     #: This field defines the GUI plugin class that contains all the code

--- a/common_utils.py
+++ b/common_utils.py
@@ -8,14 +8,15 @@ __copyright__ = '2011, Grant Drake <grant.drake@gmail.com>'
 __docformat__ = 'restructuredtext en'
 
 import os
+from contextlib import contextmanager
 
 import six
 from six import text_type as unicode
 
-from PyQt5.Qt import (Qt, QIcon, QPixmap, QLabel, QDialog, QHBoxLayout,
+from PyQt5.Qt import (QApplication, Qt, QIcon, QPixmap, QLabel, QDialog, QHBoxLayout,
                       QTableWidgetItem, QFont, QLineEdit, QComboBox,
                       QVBoxLayout, QDialogButtonBox, QStyledItemDelegate, QDateTime,
-                      QTextEdit,
+                      QTextEdit, QCursor,
                       QListWidget, QAbstractItemView)
 
 from calibre.constants import numeric_version as calibre_version
@@ -189,6 +190,14 @@ def get_library_uuid(db):
         library_uuid = ''
     return library_uuid
 
+# Call as ' with busy_cursor:"
+@contextmanager
+def busy_cursor():
+    try:
+        QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
+        yield
+    finally:
+        QApplication.restoreOverrideCursor()
 
 class ImageTitleLayout(QHBoxLayout):
     '''

--- a/config.py
+++ b/config.py
@@ -43,7 +43,7 @@ default_prefs['flattentoc'] = False
 default_prefs['includecomments'] = False
 default_prefs['titlenavpoints'] = True
 default_prefs['originalnavpoints'] = True
-default_prefs['removesingletoc'] = True
+default_prefs['removesingletocs'] = True
 default_prefs['keepmeta'] = True
 default_prefs['restore_selection'] = False
 #default_prefs['showunmerge'] = True
@@ -149,7 +149,7 @@ class ConfigWidget(QWidget):
         prefs['includecomments'] = self.basic_tab.includecomments.isChecked()
         prefs['titlenavpoints'] = self.basic_tab.titlenavpoints.isChecked()
         prefs['originalnavpoints'] = self.basic_tab.originalnavpoints.isChecked()
-        prefs['removesingletoc'] = self.basic_tab.removesingletoc.isChecked()
+        prefs['removesingletocs'] = self.basic_tab.removesingletocs.isChecked()
         prefs['keepmeta'] = self.basic_tab.keepmeta.isChecked()
         prefs['restore_selection'] = self.basic_tab.restore_selection.isChecked()
         # prefs['showunmerge'] = self.basic_tab.showunmerge.isChecked()
@@ -213,15 +213,16 @@ it's existing TOC nested underneath it.''')+'\n'+no_toc_warning)
         self.originalnavpoints.stateChanged.connect(f)
 
         ## note that internal to epubmerge.py, the flag is reversed to
-        ## keepsingletoc
-        self.removesingletoc = QCheckBox(_('Skip when there is only one TOC entry?'),self)
-        self.removesingletoc.setToolTip(_('''If set, the original TOC entries for each book will only be included if there's more than one.'''))
-        self.removesingletoc.setChecked(prefs['removesingletoc'])
+        ## keepsingletocs
+        self.removesingletocs = QCheckBox(_('Skip when there is only one TOC entry?'),self)
+        self.removesingletocs.setToolTip(_('''If set, the original TOC entries for each book will only be included
+if there's more than TOC entry one in that book.'''))
+        self.removesingletocs.setChecked(prefs['removesingletocs'])
         horz = QHBoxLayout()
         horz.addItem(QtGui.QSpacerItem(20, 1))
         vertright = QVBoxLayout()
         horz.addLayout(vertright)
-        vertright.addWidget(self.removesingletoc)
+        vertright.addWidget(self.removesingletocs)
         self.l.addLayout(horz)
 
         self.titlenavpoints.stateChanged.connect(f)

--- a/config.py
+++ b/config.py
@@ -15,6 +15,7 @@ import traceback, copy
 import six
 from six import text_type as unicode
 
+from PyQt5 import QtWidgets as QtGui
 from PyQt5.Qt import (QDialog, QWidget, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QFont, QGridLayout,
                       QTextEdit, QComboBox, QCheckBox, QPushButton, QTabWidget, QScrollArea)
 
@@ -42,6 +43,7 @@ default_prefs['flattentoc'] = False
 default_prefs['includecomments'] = False
 default_prefs['titlenavpoints'] = True
 default_prefs['originalnavpoints'] = True
+default_prefs['removesingletoc'] = True
 default_prefs['keepmeta'] = True
 default_prefs['restore_selection'] = False
 #default_prefs['showunmerge'] = True
@@ -147,6 +149,7 @@ class ConfigWidget(QWidget):
         prefs['includecomments'] = self.basic_tab.includecomments.isChecked()
         prefs['titlenavpoints'] = self.basic_tab.titlenavpoints.isChecked()
         prefs['originalnavpoints'] = self.basic_tab.originalnavpoints.isChecked()
+        prefs['removesingletoc'] = self.basic_tab.removesingletoc.isChecked()
         prefs['keepmeta'] = self.basic_tab.keepmeta.isChecked()
         prefs['restore_selection'] = self.basic_tab.restore_selection.isChecked()
         # prefs['showunmerge'] = self.basic_tab.showunmerge.isChecked()
@@ -208,6 +211,19 @@ it's existing TOC nested underneath it.''')+'\n'+no_toc_warning)
                         parent=self,
                         show_cancel_button=False)
         self.originalnavpoints.stateChanged.connect(f)
+
+        ## note that internal to epubmerge.py, the flag is reversed to
+        ## keepsingletoc
+        self.removesingletoc = QCheckBox(_('Skip when there is only one TOC entry?'),self)
+        self.removesingletoc.setToolTip(_('''If set, the original TOC entries for each book will only be included if there's more than one.'''))
+        self.removesingletoc.setChecked(prefs['removesingletoc'])
+        horz = QHBoxLayout()
+        horz.addItem(QtGui.QSpacerItem(20, 1))
+        vertright = QVBoxLayout()
+        horz.addLayout(vertright)
+        vertright.addWidget(self.removesingletoc)
+        self.l.addLayout(horz)
+
         self.titlenavpoints.stateChanged.connect(f)
 
         self.flattentoc = QCheckBox(_('Flatten Table of Contents?'),self)

--- a/epubmerge.py
+++ b/epubmerge.py
@@ -112,8 +112,8 @@ Given list of epubs will be merged together into one new epub.
     optparser.add_option("-N", "--no-original-toc",
                       action="store_false", dest="originalnavpoints", default=True,
                       help="Default is to include the TOC from each original epub.",)
-    optparser.add_option("--keep-single-toc",
-                      action="store_true", dest="keepsingletoc",
+    optparser.add_option("--keep-single-tocs",
+                      action="store_true", dest="keepsingletocs",
                       help="Default is to add only epub title to TOC if there is only 1(or 0) entries in input TOC.  Does not apply if using --no-titles-in-toc",)
     optparser.add_option("-f", "--flatten-toc",
                       action="store_true", dest="flattentoc",
@@ -164,7 +164,7 @@ Given list of epubs will be merged together into one new epub.
                 languages=options.languageopts,
                 titlenavpoints=options.titlenavpoints,
                 originalnavpoints=options.originalnavpoints,
-                keepsingletoc=options.keepsingletoc,
+                keepsingletocs=options.keepsingletocs,
                 flattentoc=options.flattentoc,
                 coverjpgpath=options.coveropt,
                 keepmetadatafiles=options.keepmeta,
@@ -192,7 +192,7 @@ def doMerge(outputio,
             languages=['en'],
             titlenavpoints=True,
             originalnavpoints=True,
-            keepsingletoc=False,
+            keepsingletocs=False,
             flattentoc=False,
             printtimes=False,
             coverjpgpath=None,
@@ -209,7 +209,7 @@ def doMerge(outputio,
     languages = dc:language tags to include
     titlenavpoints if true, put in a new TOC entry for each epub, nesting each epub's chapters under it
     originalnavpoints if true, include the original TOCs from each epub
-    keepsingletoc if true, include original TOC even if only one entry
+    keepsingletocs if true, include original TOC even if only one entry
     flattentoc if true, flatten TOC down to one level only.
     coverjpgpath, Path to a jpg to use as cover image.
     '''
@@ -601,7 +601,7 @@ def doMerge(outputio,
         ## EITHER keep single toc option OR more than one TOC
         ## point(total, not top level), include sub book TOC entries.
         ## Each navpoint may be a whole sub tree.
-        if originalnavpoints and titlenavpoints and (keepsingletoc or len(depthnavpoints) > 1):
+        if originalnavpoints and titlenavpoints and (keepsingletocs or len(depthnavpoints) > 1):
             if not is_fff_epub[booknum]:
                 nonskip_navpoints_count = len(depthnavpoints)
             else:
@@ -633,7 +633,7 @@ def doMerge(outputio,
                         nonskip_navpoints_count += (1+len(navpoint.getElementsByTagNameNS("*","navPoint")))
                     # logger.debug("nonskip_navpoints_count:%s"%nonskip_navpoints_count)
 
-            if keepsingletoc or nonskip_navpoints_count > 1:
+            if keepsingletocs or nonskip_navpoints_count > 1:
                 for navpoint in navpoints:
                     # logger.debug("include navpoint:\n%s"%navpoint.toprettyxml())
                     newnav.appendChild(navpoint)

--- a/epubmerge.py
+++ b/epubmerge.py
@@ -309,13 +309,13 @@ def doMerge(outputio,
         ## Sigil changes the unique-identifier, but leaves dc:contributor
         ## Calibre epub3->epub2 convert changes dc:contributor and modifies dc:identifier
         for c in metadom.getElementsByTagName("dc:contributor") + metadom.getElementsByTagName("dc:identifier"):
-            logger.debug("dc:contributor/identifier:%s"%getText(c.childNodes))
-            logger.debug("dc:contributor/identifier:%s / %s"%(c.getAttribute('opf:scheme'),c.getAttribute('id')))
+            # logger.debug("dc:contributor/identifier:%s"%getText(c.childNodes))
+            # logger.debug("dc:contributor/identifier:%s / %s"%(c.getAttribute('opf:scheme'),c.getAttribute('id')))
             if ( getText(c.childNodes) in ["fanficdownloader [http://fanficdownloader.googlecode.com]",
                                            "FanFicFare [https://github.com/JimmXinu/FanFicFare]"]
                  or 'fanficfare-uid' in c.getAttribute('opf:scheme').lower()
                  or 'fanficfare-uid' in c.getAttribute('id').lower() ):
-                logger.debug("------------> is_fff_epub <-----------------")
+                # logger.debug("------------> is_fff_epub <-----------------")
                 is_fff_epub[-1] = True # set last.
                 break;
 
@@ -384,7 +384,7 @@ def doMerge(outputio,
                     items.append((itemid,href,"origtocncx/xml"))
             else:
                 #href=href.encode('utf8')
-                logger.debug("item id: %s -> %s:"%(itemid,href))
+                # logger.debug("item id: %s -> %s:"%(itemid,href))
                 itemhrefs[itemid] = href
                 if href not in filelist:
                     try:
@@ -399,7 +399,7 @@ def doMerge(outputio,
                         del itemhrefs[itemid]
 
         itemreflist = metadom.getElementsByTagNameNS("*","itemref")
-        logger.debug("itemhrefs:%s"%itemhrefs)
+        # logger.debug("itemhrefs:%s"%itemhrefs)
         logger.debug("bookid:%s"%bookid)
         logger.debug("itemreflist[0].getAttribute(idref):%s"%itemreflist[0].getAttribute("idref"))
 
@@ -413,7 +413,7 @@ def doMerge(outputio,
 
         for itemref in itemreflist:
             itemrefs.append(bookid+itemref.getAttribute("idref"))
-            logger.debug("adding to itemrefs:\n%s"%itemref.toprettyxml())
+            # logger.debug("adding to itemrefs:\n%s"%itemref.toprettyxml())
 
         notify_progress(float(booknum-1)/len(files))
         booknum=booknum+1;
@@ -520,7 +520,7 @@ def doMerge(outputio,
                                         "linear":"yes"}))
 
     for item in items:
-        logger.debug("new item:%s %s %s"%item)
+        # logger.debug("new item:%s %s %s"%item)
         (id,href,type)=item
         manifest.appendChild(newTag(contentdom,"item",
                                        attrs={'id':id,
@@ -528,7 +528,7 @@ def doMerge(outputio,
                                               'media-type':type}))
 
     for itemref in itemrefs:
-        logger.debug("itemref:%s"%itemref)
+        # logger.debug("itemref:%s"%itemref)
         spine.appendChild(newTag(contentdom,"itemref",
                                     attrs={"idref":itemref,
                                            "linear":"yes"}))
@@ -564,11 +564,11 @@ def doMerge(outputio,
 
     for navmap in navmaps:
 
-        logger.debug( [ x.toprettyxml() for x in navmap.childNodes ] )
+        # logger.debug( [ x.toprettyxml() for x in navmap.childNodes ] )
         ## only gets top level TOC entries.  sub entries carried inside.
         navpoints = [ x for x in navmap.childNodes if isinstance(x,Element) and x.tagName=="navPoint" ]
-        logger.debug("len(navpoints):%s"%len(navpoints))
-        logger.debug( [ x.toprettyxml() for x in navpoints ] )
+        # logger.debug("len(navpoints):%s"%len(navpoints))
+        # logger.debug( [ x.toprettyxml() for x in navpoints ] )
         newnav = None
         if titlenavpoints:
             newnav = newTag(tocncxdom,"navPoint",{"id":"book%03d"%booknum})
@@ -587,9 +587,9 @@ def doMerge(outputio,
             newnav.appendChild(newTag(tocncxdom,"content",
                                       {"src":firstitemhrefs[booknum]}))
 
-            logger.debug("newnav:\n%s"%newnav.toprettyxml())
+            # logger.debug("newnav:\n%s"%newnav.toprettyxml())
             tocnavMap.appendChild(newnav)
-            logger.debug("tocnavMap:\n%s"%tocnavMap.toprettyxml())
+            # logger.debug("tocnavMap:\n%s"%tocnavMap.toprettyxml())
         else:
             newnav = tocnavMap
 
@@ -609,7 +609,7 @@ def doMerge(outputio,
                 ## and/or title pages
                 nonskip_navpoints_count = 0
                 for navpoint in navpoints:
-                    logger.debug("navpoint:\n%s"%navpoint.toprettyxml())
+                    # logger.debug("navpoint:\n%s"%navpoint.toprettyxml())
 
                     # this isn't going to find title/log pages farther
                     # down a tree, but if it's truly FFF input, they
@@ -621,21 +621,21 @@ def doMerge(outputio,
                             contentsrc = n.getAttribute("src")
                             break
                     navpointid = navpoint.getAttribute("id")
-                    logger.debug("navpointid:%s"%navpointid)
-                    logger.debug("contentsrc:%s"%contentsrc)
+                    # logger.debug("navpointid:%s"%navpointid)
+                    # logger.debug("contentsrc:%s"%contentsrc)
 
                     if not ( navpointid.endswith('log_page') or
                              contentsrc.endswith("log_page.xhtml") or
                              navpointid.endswith('title_page') or
                              contentsrc.endswith("title_page.xhtml") ):
-                        logger.debug("nonskip")
+                        # logger.debug("nonskip")
                         ## 1 for this node, plus search down for nested
                         nonskip_navpoints_count += (1+len(navpoint.getElementsByTagNameNS("*","navPoint")))
-                    logger.debug("nonskip_navpoints_count:%s"%nonskip_navpoints_count)
+                    # logger.debug("nonskip_navpoints_count:%s"%nonskip_navpoints_count)
 
             if keepsingletoc or nonskip_navpoints_count > 1:
                 for navpoint in navpoints:
-                    logger.debug("include navpoint:\n%s"%navpoint.toprettyxml())
+                    # logger.debug("include navpoint:\n%s"%navpoint.toprettyxml())
                     newnav.appendChild(navpoint)
 
         booknum=booknum+1;
@@ -646,9 +646,9 @@ def doMerge(outputio,
     removednodes = []
     ## Force strict ordering of playOrder, stripping out some.
     playorder=0
-    logger.debug("tocncxdom:\n%s"%tocncxdom.toprettyxml())
+    # logger.debug("tocncxdom:\n%s"%tocncxdom.toprettyxml())
     for navpoint in tocncxdom.getElementsByTagNameNS("*","navPoint"):
-        logger.debug("navpoint:\n%s"%navpoint.toprettyxml())
+        # logger.debug("navpoint:\n%s"%navpoint.toprettyxml())
         if navpoint in removednodes:
             continue
         # need content[src] to compare for dups.  epub wants dup srcs to have same playOrder.
@@ -656,7 +656,7 @@ def doMerge(outputio,
         for n in navpoint.childNodes:
             if isinstance(n,Element) and n.tagName == "content":
                 contentsrc = n.getAttribute("src")
-                logger.debug("contentsrc: %s"%contentsrc)
+                # logger.debug("contentsrc: %s"%contentsrc)
                 break
 
         if( contentsrc not in contentsrcs ):
@@ -666,7 +666,7 @@ def doMerge(outputio,
             contentsrcs[contentsrc] = navpoint.getAttribute("id")
             playorder += 1
             navpoint.setAttribute("playOrder","%d" % playorder)
-            logger.debug("playorder:%d:"%playorder)
+            # logger.debug("playorder:%d:"%playorder)
 
             # need to know depth of deepest navpoint for <meta name="dtb:depth" content="2"/>
             npdepth = 1

--- a/epubmerge.py
+++ b/epubmerge.py
@@ -9,7 +9,7 @@ import sys, os
 import logging
 logger = logging.getLogger(__name__)
 
-version="2.15.2"
+version="2.15.3"
 
 # py2 vs py3 transition
 from six import text_type as unicode

--- a/epubmerge_plugin.py
+++ b/epubmerge_plugin.py
@@ -603,6 +603,7 @@ You are merging %s EPUBs totaling %s.''')%(len(book_list),gethumanreadable(total
                       'languages':mi.languages,
                       'titlenavpoints':prefs['titlenavpoints'],
                       'originalnavpoints':prefs['originalnavpoints'],
+                      'removesingletoc':prefs['removesingletoc'],
                       'flattentoc':prefs['flattentoc'],
                       'printtimes':True,
                       'coverjpgpath':coverjpgpath,

--- a/epubmerge_plugin.py
+++ b/epubmerge_plugin.py
@@ -603,7 +603,7 @@ You are merging %s EPUBs totaling %s.''')%(len(book_list),gethumanreadable(total
                       'languages':mi.languages,
                       'titlenavpoints':prefs['titlenavpoints'],
                       'originalnavpoints':prefs['originalnavpoints'],
-                      'removesingletoc':prefs['removesingletoc'],
+                      'removesingletocs':prefs['removesingletocs'],
                       'flattentoc':prefs['flattentoc'],
                       'printtimes':True,
                       'coverjpgpath':coverjpgpath,

--- a/epubmerge_plugin.py
+++ b/epubmerge_plugin.py
@@ -36,7 +36,9 @@ try:
 except NameError:
     pass # load_translations() added in calibre 1.9
 
-from calibre_plugins.epubmerge.common_utils import (set_plugin_icon_resources, get_icon, create_menu_action_unique )
+from calibre_plugins.epubmerge.common_utils import (
+    set_plugin_icon_resources, get_icon, create_menu_action_unique,
+    busy_cursor )
 
 from calibre_plugins.epubmerge.config import (prefs, permitted_values)
 
@@ -115,7 +117,7 @@ class EpubMergePlugin(InterfaceAction):
 
         self.unmerge_action = self.create_menu_item_ex(self.menu, _('&UnMerge Epubs'), image='images/unmerge.png',
                                                        unique_name=_('&UnMerge Epubs'),
-                                                       triggered=self.unmerge )
+                                                       triggered=self.unmerge_button )
 
 
         # logger.debug("platform.system():%s"%platform.system())
@@ -166,6 +168,10 @@ class EpubMergePlugin(InterfaceAction):
         includes back-compat files that will work for EpubMerge.
         '''
         return doMerge(*args, **kwargs)
+
+    def unmerge_button(self):
+        with busy_cursor():
+            self.unmerge()
 
     def unmerge(self):
         db=self.gui.current_db

--- a/jobs.py
+++ b/jobs.py
@@ -83,17 +83,20 @@ def do_merge_bg(args,
 
     doMerge(args['outputepubfn'],
             args['inputepubfns'],
-            args['authoropts'],
-            args['titleopt'],
-            args['descopt'],
-            args['tags'],
-            args['languages'],
-            args['titlenavpoints'],
-            args['originalnavpoints'],
-            args['flattentoc'],
-            args['printtimes'],
-            args['coverjpgpath'],
-            args['keepmetadatafiles'],
+            authoropts=args['authoropts'],
+            titleopt=args['titleopt'],
+            descopt=args['descopt'],
+            tags=args['tags'],
+            languages=args['languages'],
+            titlenavpoints=args['titlenavpoints'],
+            originalnavpoints=args['originalnavpoints'],
+            # reversed in CLI vs plugin to match reversed
+            # --no-titles-in-toc & --no-original-toc options
+            keepsingletoc=not args['removesingletoc'], 
+            flattentoc=args['flattentoc'],
+            printtimes=args['printtimes'],
+            coverjpgpath=args['coverjpgpath'],
+            keepmetadatafiles=args['keepmetadatafiles'],
             notify_progress=notify_progress)
     print("=" * 50)
     print("\nFinished Merge...\n")

--- a/jobs.py
+++ b/jobs.py
@@ -92,7 +92,7 @@ def do_merge_bg(args,
             originalnavpoints=args['originalnavpoints'],
             # reversed in CLI vs plugin to match reversed
             # --no-titles-in-toc & --no-original-toc options
-            keepsingletoc=not args['removesingletoc'], 
+            keepsingletocs=not args['removesingletocs'],
             flattentoc=args['flattentoc'],
             printtimes=args['printtimes'],
             coverjpgpath=args['coverjpgpath'],

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     name=package_name,
 
     # Versions should comply with PEP440.
-    version="2.15.2",
+    version="2.15.3",
 
     description='A tool for merging multiple epubs into one.',
     long_description=long_description,

--- a/translations/messages.pot
+++ b/translations/messages.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2023-07-07 11:17-0500\n"
+"POT-Creation-Date: 2023-07-15 16:27-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,212 +19,222 @@ msgstr ""
 msgid "UI plugin to concatenate multiple epubs into one."
 msgstr ""
 
-#: config.py:49
+#: config.py:51
 msgid "Anthology"
 msgstr ""
 
-#: config.py:139
+#: config.py:141
 msgid "Basic"
 msgstr ""
 
-#: config.py:142
+#: config.py:144
 msgid "Columns"
 msgstr ""
 
-#: config.py:186
+#: config.py:189
 msgid "These settings control the basic features of the plugin."
 msgstr ""
 
-#: config.py:191
+#: config.py:194
 msgid ""
 "If both 'Insert Table of Contents entry' and 'Copy Table of Contents entries'\n"
 "are unchecked, there will be no Table of Contents in merged books."
 msgstr ""
 
-#: config.py:193
+#: config.py:196
 msgid "Insert Table of Contents entry for each title?"
 msgstr ""
 
-#: config.py:194
+#: config.py:197
 msgid ""
 "If set, a new TOC entry will be made for each title and\n"
 "it's existing TOC nested underneath it."
 msgstr ""
 
-#: config.py:199
+#: config.py:202
 msgid "Copy Table of Contents entries from each title?"
 msgstr ""
 
-#: config.py:200
+#: config.py:203
 msgid "If set, the original TOC entries will be included the new epub."
 msgstr ""
 
-#: config.py:213
-msgid "Flatten Table of Contents?"
-msgstr ""
-
-#: config.py:214
-msgid "Remove nesting and make TOC all on one level."
+#: config.py:217
+msgid "Skip when there is only one TOC entry?"
 msgstr ""
 
 #: config.py:218
+msgid ""
+"If set, the original TOC entries for each book will only be included\n"
+"if there's more than TOC entry one in that book."
+msgstr ""
+
+#: config.py:230
+msgid "Flatten Table of Contents?"
+msgstr ""
+
+#: config.py:231
+msgid "Remove nesting and make TOC all on one level."
+msgstr ""
+
+#: config.py:235
 msgid "Include Books' Comments?"
 msgstr ""
 
-#: config.py:219
+#: config.py:236
 msgid ""
 "Include all the merged books' comments in the new book's comments.\n"
 "Default is a list of included titles only."
 msgstr ""
 
-#: config.py:224
+#: config.py:241
 msgid "Keep UnMerge Metadata?"
 msgstr ""
 
-#: config.py:225
+#: config.py:242
 msgid ""
 "If set, a copy of the original metadata for each merged book will\n"
 "be included, allowing for UnMerge.  This includes your calibre custom\n"
 "columns.  Leave off if you plan to distribute the epub to others."
 msgstr ""
 
-#: config.py:231
+#: config.py:248
 msgid "Restore Selection?"
 msgstr ""
 
-#: config.py:232
+#: config.py:249
 msgid ""
 "If set, the plugin will select the same books again after starting\n"
 "the merge.  Default behavior is to select the new merge book."
 msgstr ""
 
-#: config.py:244
+#: config.py:261
 msgid "Add tags to merged books:"
 msgstr ""
 
-#: config.py:248
+#: config.py:265
 msgid "Tags you enter here will be added to all new merged books"
 msgstr ""
 
-#: config.py:253
+#: config.py:270
 msgid "Merged Book Word:"
 msgstr ""
 
-#: config.py:257
+#: config.py:274
 msgid ""
 "Word use to describe merged books in default title and summary.\n"
 "For people who don't like the word Anthology."
 msgstr ""
 
-#: config.py:266
+#: config.py:283
 msgid "These controls aren't plugin settings as such, but convenience buttons for setting Keyboard shortcuts and getting all the EpubMerge confirmation dialogs back again."
 msgstr ""
 
-#: config.py:271
+#: config.py:288
 msgid "Keyboard shortcuts..."
 msgstr ""
 
-#: config.py:272
+#: config.py:289
 msgid "Edit the keyboard shortcuts associated with this plugin"
 msgstr ""
 
-#: config.py:276
+#: config.py:293
 msgid "Reset disabled &confirmation dialogs"
 msgstr ""
 
-#: config.py:277
+#: config.py:294
 msgid "Reset all show me again dialogs for the EpubMerge plugin"
 msgstr ""
 
-#: config.py:281
+#: config.py:298
 msgid "View library preferences..."
 msgstr ""
 
-#: config.py:282
+#: config.py:299
 msgid "View data stored in the library database for this plugin"
 msgstr ""
 
-#: config.py:297
+#: config.py:314
 msgid "Done"
 msgstr ""
 
-#: config.py:298
+#: config.py:315
 msgid "Confirmation dialogs have all been reset"
 msgstr ""
 
-#: config.py:314
+#: config.py:331
 msgid "Take value from first source book"
 msgstr ""
 
-#: config.py:315
+#: config.py:332
 msgid "Take value from last source book"
 msgstr ""
 
-#: config.py:316
+#: config.py:333
 msgid "Add values from all source books"
 msgstr ""
 
-#: config.py:317
+#: config.py:334
 msgid "Average value from ALL source books"
 msgstr ""
 
-#: config.py:318
+#: config.py:335
 msgid "Average value from source books with values"
 msgstr ""
 
-#: config.py:319
+#: config.py:336
 msgid "True if true on all source books (and)"
 msgstr ""
 
-#: config.py:320
+#: config.py:337
 msgid "True if true on any source books (or)"
 msgstr ""
 
-#: config.py:321
+#: config.py:338
 msgid "Take newest value from source books"
 msgstr ""
 
-#: config.py:322
+#: config.py:339
 msgid "Take oldest value from source books"
 msgstr ""
 
-#: config.py:323
+#: config.py:340
 msgid "Include values from all source books"
 msgstr ""
 
-#: config.py:324
+#: config.py:341
 msgid "Concatenate values from all source books"
 msgstr ""
 
-#: config.py:325
+#: config.py:342
 msgid "Set to current time when created"
 msgstr ""
 
-#: config.py:338
+#: config.py:355
 msgid "Standard Columns:"
 msgstr ""
 
-#: config.py:343
+#: config.py:360
 msgid "Take Series from first book"
 msgstr ""
 
-#: config.py:344
+#: config.py:361
 msgid "If set, the Series name and index from the first book will be set on the merged book."
 msgstr ""
 
-#: config.py:349
+#: config.py:366
 msgid "Custom Columns:"
 msgstr ""
 
-#: config.py:352
+#: config.py:369
 msgid "If you have custom columns defined, they will be listed below.  Choose how you would like these columns handled."
 msgstr ""
 
-#: config.py:378
+#: config.py:395
 msgid "Set this %s column on new merged books..."
 msgstr ""
 
-#: config.py:393
+#: config.py:410
 msgid "How this column will be populated by default."
 msgstr ""
 
@@ -304,152 +314,152 @@ msgstr ""
 msgid "Discard"
 msgstr ""
 
-#: epubmerge_plugin.py:61 epubmerge_plugin.py:540 epubmerge_plugin.py:556
-#: epubmerge_plugin.py:666
+#: epubmerge_plugin.py:63 epubmerge_plugin.py:546 epubmerge_plugin.py:562
+#: epubmerge_plugin.py:673
 msgid "EpubMerge"
 msgstr ""
 
-#: epubmerge_plugin.py:62
+#: epubmerge_plugin.py:64
 msgid "Merge multiple EPUBs into one in a new book."
 msgstr ""
 
-#: epubmerge_plugin.py:112 epubmerge_plugin.py:113
+#: epubmerge_plugin.py:114 epubmerge_plugin.py:115
 msgid "&Merge Epubs"
 msgstr ""
 
-#: epubmerge_plugin.py:116 epubmerge_plugin.py:117
+#: epubmerge_plugin.py:118 epubmerge_plugin.py:119
 msgid "&UnMerge Epubs"
 msgstr ""
 
-#: epubmerge_plugin.py:126
+#: epubmerge_plugin.py:128
 msgid "&Configure Plugin"
 msgstr ""
 
-#: epubmerge_plugin.py:128 epubmerge_plugin.py:129
+#: epubmerge_plugin.py:130 epubmerge_plugin.py:131
 msgid "Configure EpubMerge"
 msgstr ""
 
-#: epubmerge_plugin.py:180
+#: epubmerge_plugin.py:186
 msgid "Cannot UnMerge Non-Epubs"
 msgstr ""
 
-#: epubmerge_plugin.py:181 epubmerge_plugin.py:192
+#: epubmerge_plugin.py:187 epubmerge_plugin.py:198
 msgid "To UnMerge the source must be Epub(s) created by EpubMerge with Keep UnMerge Metadata enabled."
 msgstr ""
 
-#: epubmerge_plugin.py:191
+#: epubmerge_plugin.py:197
 msgid "No UnMerge data found"
 msgstr ""
 
-#: epubmerge_plugin.py:208
+#: epubmerge_plugin.py:214
 msgid "You already have a book <i>%s</i> by <i>%s</i>.  You may Add a new book of the same title, Overwrite the Epub in the existing book, or Discard this Epub."
 msgstr ""
 
-#: epubmerge_plugin.py:211
+#: epubmerge_plugin.py:217
 msgid "You already have more than one book <i>%s</i> by <i>%s</i>.  You may Add a new book of the same title, or Discard this Epub."
 msgstr ""
 
-#: epubmerge_plugin.py:251 epubmerge_plugin.py:283
+#: epubmerge_plugin.py:257 epubmerge_plugin.py:289
 msgid "Cannot Merge Epubs"
 msgstr ""
 
-#: epubmerge_plugin.py:252
+#: epubmerge_plugin.py:258
 msgid "Less than 2 books selected."
 msgstr ""
 
-#: epubmerge_plugin.py:272
+#: epubmerge_plugin.py:278
 msgid "Collecting EPUBs for merger..."
 msgstr ""
 
-#: epubmerge_plugin.py:273
+#: epubmerge_plugin.py:279
 msgid "Get EPUBs for merge"
 msgstr ""
 
-#: epubmerge_plugin.py:274
+#: epubmerge_plugin.py:280
 msgid "EPUBs collected"
 msgstr ""
 
-#: epubmerge_plugin.py:284
+#: epubmerge_plugin.py:290
 msgid "%s books failed."
 msgstr ""
 
-#: epubmerge_plugin.py:289
+#: epubmerge_plugin.py:295
 msgid "Order EPUBs to Merge"
 msgstr ""
 
-#: epubmerge_plugin.py:356 epubmerge_plugin.py:575
+#: epubmerge_plugin.py:362 epubmerge_plugin.py:581
 msgid "%s by %s"
 msgstr ""
 
-#: epubmerge_plugin.py:360
+#: epubmerge_plugin.py:366
 msgid "%s containing:"
 msgstr ""
 
-#: epubmerge_plugin.py:535
+#: epubmerge_plugin.py:541
 msgid ""
 "The book for the new Merged EPUB has been created and default metadata filled in.\n"
 "\n"
 "However, the EPUB will *not* be created until after you've reviewed, edited, and closed the metadata dialog that follows."
 msgstr ""
 
-#: epubmerge_plugin.py:551
+#: epubmerge_plugin.py:557
 msgid ""
 "EpubMerge will be done in a Background job.  The merged EPUB will not appear in the Library until finished.\n"
 "\n"
 "You are merging %s EPUBs totaling %s."
 msgstr ""
 
-#: epubmerge_plugin.py:564
+#: epubmerge_plugin.py:570
 msgid "Merging %s EPUBs..."
 msgstr ""
 
-#: epubmerge_plugin.py:606
+#: epubmerge_plugin.py:613
 msgid "EpubMerge: %s"
 msgstr ""
 
-#: epubmerge_plugin.py:617
+#: epubmerge_plugin.py:624
 msgid "Starting EpubMerge"
 msgstr ""
 
-#: epubmerge_plugin.py:625 epubmerge_plugin.py:631
+#: epubmerge_plugin.py:632 epubmerge_plugin.py:638
 msgid "Remove Failed Anthology Book?"
 msgstr ""
 
-#: epubmerge_plugin.py:632
+#: epubmerge_plugin.py:639
 msgid "EpubMerge failed, no new EPUB was created; see the background job details for any error messages."
 msgstr ""
 
-#: epubmerge_plugin.py:633
+#: epubmerge_plugin.py:640
 msgid "Do you want to delete the empty book EpubMerge created?"
 msgstr ""
 
-#: epubmerge_plugin.py:634
+#: epubmerge_plugin.py:641
 msgid "Click '<b>Yes</b>' to remove empty book from Libary,"
 msgstr ""
 
-#: epubmerge_plugin.py:635
+#: epubmerge_plugin.py:642
 msgid "Click '<b>No</b>' to leave it in Library."
 msgstr ""
 
-#: epubmerge_plugin.py:643
+#: epubmerge_plugin.py:650
 msgid ""
 "Merge finished, output in:\n"
 "%s"
 msgstr ""
 
-#: epubmerge_plugin.py:655
+#: epubmerge_plugin.py:662
 msgid "Finished merging %s EPUBs."
 msgstr ""
 
-#: epubmerge_plugin.py:663
+#: epubmerge_plugin.py:670
 msgid "EpubMerge has finished. The new EPUB has been added to the book previously created."
 msgstr ""
 
-#: epubmerge_plugin.py:677 epubmerge_plugin.py:678 epubmerge_plugin.py:679
+#: epubmerge_plugin.py:684 epubmerge_plugin.py:685 epubmerge_plugin.py:686
 msgid "Unknown"
 msgstr ""
 
-#: epubmerge_plugin.py:720
+#: epubmerge_plugin.py:727
 msgid "%s by %s doesn't have an EPUB."
 msgstr ""
 


### PR DESCRIPTION
I don't usually bother with PRs to my own repos, but I'd like a durable way to link these changes back to [FanFicFare PR977](https://github.com/JimmXinu/FanFicFare/issues/977).

These changes:
- Fix the issue @Chirishman identified with an input FFF book having a cover preventing the single chapter special code from activating.
- Introduce a new `--keep-single-tocs` CLI option and a logically reversed option in the plugin, a checkbox: 'Skip when there is only one TOC entry' under the existing 'Copy Table of Contents entries from each title' checkbox, both checked by default.

Making FanFicFare _use_ that setting will require changes in FFF that will depend on these changes..