### PR TITLE
Fix cli command error

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -102,5 +102,5 @@ class EpubMergeBase(InterfaceActionBase):
             ac.apply_settings()
 
     def cli_main(self,argv):
-        from calibre_plugins.epubmerge.epubmerge import main as epubmerge_main
+        from calibre_plugins.epubmerge.epubmerge.epubmerge import main as epubmerge_main
         epubmerge_main(argv[1:],usage='%prog --run-plugin '+self.name+' --')


### PR DESCRIPTION
command: calibre-debug --run-plugin=EpubMerge

error occured
```
Traceback (most recent call last):
  File "runpy.py", line 198, in _run_module_as_main
  File "runpy.py", line 88, in _run_code
  File "site.py", line 47, in <module>
  File "site.py", line 43, in main
  File "calibre/debug.py", line 289, in main
  File "calibre_plugins.epubmerge.__init__", line 105, in cli_main
ImportError: cannot import name 'main' from 'calibre_plugins.epubmerge.epubmerge' (/home/<user_name>/.config/calibre/plugins/EpubMerge.zip/epubmerge/__init__.py)
```