### PR TITLE
Add support for uploading local epubs to merge.

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -28,6 +28,7 @@ from calibre.gui2 import choose_files
 from calibre.ebooks.metadata.epub import get_metadata
 from calibre.gui2.dialogs.confirm_delete import confirm
 from calibre.ebooks.metadata import fmt_sidx
+from calibre.ptempfile import PersistentTemporaryDirectory
 
 from calibre import confirm_config_name
 from calibre.gui2 import dynamic
@@ -213,6 +214,51 @@ class OrderEPUBsDialog(SizePersistedDialog):
     def get_books(self):
         return self.books_table.get_books()
     
+    def populate_book_from_local_upload(self, book, db=None, tdir=None):
+        try:
+            filepath = book['epub']
+            with open(filepath, 'rb') as f:
+                mi = get_metadata(f)
+            
+            book['calibre_id'] = None
+            book['title'] = mi.title or _('Unknown')
+            book['authors'] = mi.authors or [_('Unknown')]
+            book['author_sort'] = mi.author_sort or _('Unknown')
+            book['tags'] = mi.tags or []
+            book['series'] = mi.series or ''
+            book['comments'] = mi.comments or ''
+            book['publisher'] = mi.publisher or ''
+            book['pubdate'] = mi.pubdate or None
+            book['series_index'] = mi.series_index if mi.series else None
+            book['languages'] = mi.languages or ['en']
+            book['error'] = ''
+            book['epub_size'] = os.path.getsize(filepath)
+
+            return book
+            
+        except Exception as e:
+            book['good'] = False
+            book['error'] = str(e)
+            raise e
+        
+    def _append_book_to_table(self, book_list, db=None, tdir=None):
+        failed_files = []
+        for book in book_list:
+            if book.get('good'):
+                row = self.books_table.rowCount()
+                self.books_table.setRowCount(row + 1)
+                self.books_table.populate_table_row(row, book)
+                self.books_table.books[row] = book
+            else:
+                failed_files.append(f"{os.path.basename(book['epub'])}: {book.get('error') or book.get('comment')}")
+        
+        self.books_table.resizeColumnsToContents()
+        
+        if failed_files:
+            error_dialog(self, _('Error reading files'),
+                         _('Could not read metadata from the following files:<br><br>%s') % '<br>'.join(failed_files),
+                         show_copy_button=False).exec_()
+    
     def local_upload(self):
         
         files = choose_files(self, 'epubmerge:local_upload_dialog',
@@ -221,40 +267,24 @@ class OrderEPUBsDialog(SizePersistedDialog):
                              all_files=False, select_only_single_file=False)
         if not files:
             return
-            
+ 
+        book_list = []
         for filepath in files:
-            try:
-                with open(filepath, 'rb') as f:
-                    mi = get_metadata(f)
-                
-                book = {
-                    'good': True,
-                    'calibre_id': None,
-                    'title': mi.title or _('Unknown'),
-                    'authors': mi.authors or [_('Unknown')],
-                    'author_sort': mi.author_sort or _('Unknown'),
-                    'tags': mi.tags or [],
-                    'series': mi.series or '',
-                    'comments': mi.comments or '',
-                    'publisher': mi.publisher or '',
-                    'pubdate': mi.pubdate or None,
-                    'series_index': mi.series_index if mi.series else None,
-                    'languages': mi.languages or ['en'],
-                    'error': '',
-                    'epub': filepath,
-                    'epub_size': os.path.getsize(filepath)
-                }
-                
-                # Append to books_table
-                row = self.books_table.rowCount()
-                self.books_table.setRowCount(row + 1)
-                self.books_table.populate_table_row(row, book)
-                self.books_table.books[row] = book
-                
-            except Exception as e:
-                error_dialog(self, _('Error reading file'),
-                             _('Could not read metadata from %s:<br>%s') % (filepath, str(e)),
-                             show_copy_button=False).exec_()
+            book_list.append({
+                'good': True,
+                'epub': filepath,
+                'epub_size': os.path.getsize(filepath)
+            })
+
+        tdir = PersistentTemporaryDirectory(prefix='epubmerge_')
+        LoopProgressDialog(self.gui,
+                            book_list,
+                            partial(self.populate_book_from_local_upload, db=self.gui.current_db, tdir=tdir),
+                            partial(self._append_book_to_table,tdir=tdir),
+                            init_label=_("Collecting EPUBs for merger..."),
+                            win_title=_("Get EPUBs for merge"),
+                            status_prefix=_("EPUBs collected"))
+
 
 class StoryListTableWidget(QTableWidget):
 

--- a/dialogs.py
+++ b/dialogs.py
@@ -3,6 +3,7 @@
 from __future__ import (unicode_literals, division,
                         print_function)
 
+import os
 import logging
 logger = logging.getLogger(__name__)
 
@@ -23,6 +24,8 @@ from PyQt5.Qt import (QDialog, QTableWidget, QMessageBox, QVBoxLayout, QHBoxLayo
                       QProgressDialog, QTimer, QDialogButtonBox, QPixmap, Qt,QAbstractItemView )
 
 from calibre.gui2 import error_dialog, warning_dialog, question_dialog, info_dialog
+from calibre.gui2 import choose_files
+from calibre.ebooks.metadata.epub import get_metadata
 from calibre.gui2.dialogs.confirm_delete import confirm
 from calibre.ebooks.metadata import fmt_sidx
 
@@ -183,6 +186,11 @@ class OrderEPUBsDialog(SizePersistedDialog):
         self.move_down_button.setIcon(QIcon(I('arrow-down.png')))
         self.move_down_button.clicked.connect(self.books_table.move_rows_down)
         button_layout.addWidget(self.move_down_button)
+        self.local_upload_button = QtGui.QToolButton(self)
+        self.local_upload_button.setToolTip(_('Add EPUBs from PC...'))
+        self.local_upload_button.setIcon(get_icon('add_book.png'))
+        self.local_upload_button.clicked.connect(self.local_upload)
+        button_layout.addWidget(self.local_upload_button)
         spacerItem1 = QtGui.QSpacerItem(20, 40, QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Expanding)
         button_layout.addItem(spacerItem1)
 
@@ -204,6 +212,49 @@ class OrderEPUBsDialog(SizePersistedDialog):
 
     def get_books(self):
         return self.books_table.get_books()
+    
+    def local_upload(self):
+        
+        files = choose_files(self, 'epubmerge:local_upload_dialog',
+                             _('Choose EPUB files to merge'),
+                             filters=[(_('EPUB files'), ['epub'])],
+                             all_files=False, select_only_single_file=False)
+        if not files:
+            return
+            
+        for filepath in files:
+            try:
+                with open(filepath, 'rb') as f:
+                    mi = get_metadata(f)
+                
+                book = {
+                    'good': True,
+                    'calibre_id': None,
+                    'title': mi.title or _('Unknown'),
+                    'authors': mi.authors or [_('Unknown')],
+                    'author_sort': mi.author_sort or _('Unknown'),
+                    'tags': mi.tags or [],
+                    'series': mi.series or '',
+                    'comments': mi.comments or '',
+                    'publisher': mi.publisher or '',
+                    'pubdate': mi.pubdate or None,
+                    'series_index': mi.series_index if mi.series else None,
+                    'languages': mi.languages or ['en'],
+                    'error': '',
+                    'epub': filepath,
+                    'epub_size': os.path.getsize(filepath)
+                }
+                
+                # Append to books_table
+                row = self.books_table.rowCount()
+                self.books_table.setRowCount(row + 1)
+                self.books_table.populate_table_row(row, book)
+                self.books_table.books[row] = book
+                
+            except Exception as e:
+                error_dialog(self, _('Error reading file'),
+                             _('Could not read metadata from %s:<br>%s') % (filepath, str(e)),
+                             show_copy_button=False).exec_()
 
 class StoryListTableWidget(QTableWidget):
 

--- a/epubmerge_plugin.py
+++ b/epubmerge_plugin.py
@@ -252,10 +252,10 @@ class EpubMergePlugin(InterfaceAction):
     def plugin_button(self):
         self.t = time.time()
 
-        if len(self.gui.library_view.get_selected_ids()) < 2:
+        if len(self.gui.library_view.get_selected_ids()) < 1:
             d = error_dialog(self.gui,
                              _('Cannot Merge Epubs'),
-                             _('Less than 2 books selected.'),
+                             _('No books selected.'),
                              show_copy_button=False)
             d.exec_()
         else:
@@ -302,6 +302,14 @@ class EpubMergePlugin(InterfaceAction):
                 return
 
             book_list = d.get_books()
+
+            if len(book_list) < 2:
+                d = error_dialog(self.gui,
+                                 _('Cannot Merge Epubs'),
+                                 _('Less than 2 books in merge list.'),
+                                 show_copy_button=False)
+                d.exec_()
+                return
 
             logger.debug("2:%s"%(time.time()-self.t))
             self.t = time.time()


### PR DESCRIPTION
This commit adds support for users to upload their own local files to EpubMerge, removing the extra step of needing them to upload the required books into Calibre first.

<img width="827" height="467" alt="image" src="https://github.com/user-attachments/assets/057391cd-d42a-463e-a782-3db386596964" />

Uploded books still respect the order of the list and can even be merge targets if they are at the top:
<img width="1014" height="860" alt="image" src="https://github.com/user-attachments/assets/718d6cbf-0a82-4d5c-b321-c70c69741946" />

Multiple books can be selected at once during upload which should help save time and make it easier for users to merge large numbers of books without cluttering their library.
<img width="827" height="467" alt="image" src="https://github.com/user-attachments/assets/c0fe518d-ce98-4f3c-8f1b-64ef3c16a90b" />

As a result of this change users can now open EpubMerge with only one book selected in their library instead of two. I'm not sure if I will change this but for now it means that at least one book will have metadata for plugin to work with, rather than relying on the plugin to both merge and make a whole new book with no initial backup inside Calibre